### PR TITLE
Moises/dspace compatibility overlay

### DIFF
--- a/docker/rosdep.yaml
+++ b/docker/rosdep.yaml
@@ -1,6 +1,3 @@
-novatel_oem7_msgs: 
-    ubuntu: 
-        jammy:  [ros-humble-novatel-oem7-msgs]
 art_novatel_oem7_msgs:
     ubuntu:
-        jammy: [ros-humble-novatel-oem7-msgs]
+        jammy: []

--- a/docker/rosdep.yaml
+++ b/docker/rosdep.yaml
@@ -1,3 +1,6 @@
 novatel_oem7_msgs: 
     ubuntu: 
         jammy:  [ros-humble-novatel-oem7-msgs]
+art_novatel_oem7_msgs:
+    ubuntu:
+        jammy: [ros-humble-novatel-oem7-msgs]

--- a/src/novatel_oem7_driver/CMakeLists.txt
+++ b/src/novatel_oem7_driver/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(sensor_msgs REQUIRED)
 find_package(nmea_msgs REQUIRED)
 find_package(nav_msgs REQUIRED)
 find_package(tf2_geometry_msgs REQUIRED)
-find_package(novatel_oem7_msgs REQUIRED)
+find_package(art_novatel_oem7_msgs REQUIRED)
 find_package(backward_ros REQUIRED)
 find_package(Boost  			REQUIRED)
 
@@ -121,7 +121,7 @@ ament_target_dependencies(${PROJECT_NAME}
 	nmea_msgs 	
 	nav_msgs
 	tf2_geometry_msgs 
-	novatel_oem7_msgs
+	art_novatel_oem7_msgs
 	backward_ros
 )
 
@@ -130,7 +130,7 @@ ament_target_dependencies(${PROJECT_NAME}_exe
     rclcpp
     rclcpp_components
 	pluginlib
-	novatel_oem7_msgs
+	art_novatel_oem7_msgs
 	backward_ros 
 )
 

--- a/src/novatel_oem7_driver/include/novatel_oem7_driver/oem7_message_decoder_if.hpp
+++ b/src/novatel_oem7_driver/include/novatel_oem7_driver/oem7_message_decoder_if.hpp
@@ -33,7 +33,7 @@
 #include <oem7_raw_message_if.hpp>
 #include <novatel_oem7_driver/oem7_receiver_if.hpp>
 
-#include "novatel_oem7_msgs/msg/oem7_raw_msg.hpp"
+#include "art_novatel_oem7_msgs/msg/oem7_raw_msg.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 

--- a/src/novatel_oem7_driver/include/novatel_oem7_driver/oem7_message_util.hpp
+++ b/src/novatel_oem7_driver/include/novatel_oem7_driver/oem7_message_util.hpp
@@ -25,8 +25,8 @@
 #ifndef __OEM7_MESSAGE_UTIL_HPP__
 #define __OEM7_MESSAGE_UTIL_HPP__
 
-#include "novatel_oem7_msgs/msg/oem7_header.hpp"
-#include "novatel_oem7_msgs/msg/oem7_raw_msg.hpp"
+#include "art_novatel_oem7_msgs/msg/oem7_header.hpp"
+#include "art_novatel_oem7_msgs/msg/oem7_raw_msg.hpp"
 
 #include "novatel_oem7_driver/oem7_message_ids.h"
 
@@ -71,7 +71,7 @@ namespace novatel_oem7_driver
    */
   void getOem7Header(
       const Oem7RawMessageIf::ConstPtr& raw_msg, ///< [in] Raw binary message
-      novatel_oem7_msgs::msg::Oem7Header& hdr   ///< [out] Oem7 Message Header
+      art_novatel_oem7_msgs::msg::Oem7Header& hdr   ///< [out] Oem7 Message Header
       );
 
   /**
@@ -80,7 +80,7 @@ namespace novatel_oem7_driver
    */
   void getOem7ShortHeader(
       const Oem7RawMessageIf::ConstPtr& raw_msg, ///< [in] Raw binary message
-      novatel_oem7_msgs::msg::Oem7Header& hdr   ///< [out] Oem7 Message Header
+      art_novatel_oem7_msgs::msg::Oem7Header& hdr   ///< [out] Oem7 Message Header
       );
 
   bool isNMEAMessage(const Oem7RawMessageIf::ConstPtr& raw_msg);

--- a/src/novatel_oem7_driver/package.xml
+++ b/src/novatel_oem7_driver/package.xml
@@ -20,7 +20,7 @@
   <depend>sensor_msgs</depend>
   <depend>nmea_msgs</depend>
   <depend>nav_msgs</depend>
-  <depend>novatel_oem7_msgs</depend>
+  <depend>art_novatel_oem7_msgs</depend>
   <depend>tf2_geometry_msgs</depend>
   <depend>geographiclib</depend>
   <depend>backward_ros</depend>

--- a/src/novatel_oem7_driver/src/align_handler.cpp
+++ b/src/novatel_oem7_driver/src/align_handler.cpp
@@ -28,9 +28,9 @@
 
 
 #include <novatel_oem7_driver/oem7_ros_messages.hpp>
-#include <novatel_oem7_msgs/msg/heading2.hpp>
-#include "novatel_oem7_msgs/msg/masterpos.hpp"
-#include "novatel_oem7_msgs/msg/roverpos.hpp"
+#include <art_novatel_oem7_msgs/msg/heading2.hpp>
+#include "art_novatel_oem7_msgs/msg/masterpos.hpp"
+#include "art_novatel_oem7_msgs/msg/roverpos.hpp"
 
 #include <oem7_ros_publisher.hpp>
 
@@ -43,15 +43,15 @@ namespace novatel_oem7_driver
    */
   class ALIGNHandler: public Oem7MessageHandlerIf
   {
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::HEADING2>> HEADING2_pub_; ///< Publisher for NMEA sentences;
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::MASTERPOS>> MASTERPOS_pub_;
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::ROVERPOS>> ROVERPOS_pub_;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::HEADING2>> HEADING2_pub_; ///< Publisher for NMEA sentences;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::MASTERPOS>> MASTERPOS_pub_;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::ROVERPOS>> ROVERPOS_pub_;
 
 
     void publishHEADING2(
         Oem7RawMessageIf::ConstPtr msg)
     {
-      std::shared_ptr<novatel_oem7_msgs::msg::HEADING2> heading2;
+      std::shared_ptr<art_novatel_oem7_msgs::msg::HEADING2> heading2;
       MakeROSMessage(msg, heading2);
       HEADING2_pub_->publish(heading2);
     }
@@ -59,7 +59,7 @@ namespace novatel_oem7_driver
     void publishMASTERPOS(
         Oem7RawMessageIf::ConstPtr msg)
     {
-      std::shared_ptr<novatel_oem7_msgs::msg::MASTERPOS> masterpos;
+      std::shared_ptr<art_novatel_oem7_msgs::msg::MASTERPOS> masterpos;
       MakeROSMessage(msg, masterpos);
       MASTERPOS_pub_->publish(masterpos);
     }
@@ -67,7 +67,7 @@ namespace novatel_oem7_driver
     void publishROVERPOS(
         Oem7RawMessageIf::ConstPtr msg)
     {
-      std::shared_ptr<novatel_oem7_msgs::msg::ROVERPOS> roverpos;
+      std::shared_ptr<art_novatel_oem7_msgs::msg::ROVERPOS> roverpos;
       MakeROSMessage(msg, roverpos);
       ROVERPOS_pub_->publish(roverpos);
     }
@@ -83,9 +83,9 @@ namespace novatel_oem7_driver
 
     void initialize(rclcpp::Node& node)
     {
-      HEADING2_pub_ = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::HEADING2>>("HEADING2", node);
-      MASTERPOS_pub_ = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::MASTERPOS>>("MASTERPOS", node);
-      ROVERPOS_pub_ = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::ROVERPOS>>("ROVERPOS", node);
+      HEADING2_pub_ = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::HEADING2>>("HEADING2", node);
+      MASTERPOS_pub_ = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::MASTERPOS>>("MASTERPOS", node);
+      ROVERPOS_pub_ = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::ROVERPOS>>("ROVERPOS", node);
     }
 
     const MessageIdRecords& getMessageIds()

--- a/src/novatel_oem7_driver/src/bestpos_handler.cpp
+++ b/src/novatel_oem7_driver/src/bestpos_handler.cpp
@@ -31,16 +31,16 @@
 #include <oem7_ros_publisher.hpp>
 #include <driver_parameter.hpp>
 
-#include "novatel_oem7_msgs/msg/solution_status.hpp"
-#include "novatel_oem7_msgs/msg/position_or_velocity_type.hpp"
-#include "novatel_oem7_msgs/msg/ppppos.hpp"
-#include "novatel_oem7_msgs/msg/bestpos.hpp"
-#include "novatel_oem7_msgs/msg/bestutm.hpp"
-#include "novatel_oem7_msgs/msg/bestvel.hpp"
-#include "novatel_oem7_msgs/msg/bestgnsspos.hpp"
-#include "novatel_oem7_msgs/msg/bestgnssvel.hpp"
-#include "novatel_oem7_msgs/msg/inspva.hpp"
-#include "novatel_oem7_msgs/msg/inspvax.hpp"
+#include "art_novatel_oem7_msgs/msg/solution_status.hpp"
+#include "art_novatel_oem7_msgs/msg/position_or_velocity_type.hpp"
+#include "art_novatel_oem7_msgs/msg/ppppos.hpp"
+#include "art_novatel_oem7_msgs/msg/bestpos.hpp"
+#include "art_novatel_oem7_msgs/msg/bestutm.hpp"
+#include "art_novatel_oem7_msgs/msg/bestvel.hpp"
+#include "art_novatel_oem7_msgs/msg/bestgnsspos.hpp"
+#include "art_novatel_oem7_msgs/msg/bestgnssvel.hpp"
+#include "art_novatel_oem7_msgs/msg/inspva.hpp"
+#include "art_novatel_oem7_msgs/msg/inspvax.hpp"
 
 #include "gps_msgs/msg/gps_fix.hpp"
 #include "sensor_msgs/msg/nav_sat_fix.hpp"
@@ -59,14 +59,14 @@ using gps_msgs::msg::GPSStatus;
 using sensor_msgs::msg::NavSatFix;
 using sensor_msgs::msg::NavSatStatus;
 
-using novatel_oem7_msgs::msg::PPPPOS;
-using novatel_oem7_msgs::msg::BESTPOS;
-using novatel_oem7_msgs::msg::BESTVEL;
-using novatel_oem7_msgs::msg::BESTUTM;
-using novatel_oem7_msgs::msg::BESTGNSSPOS;
-using novatel_oem7_msgs::msg::BESTGNSSVEL;
-using novatel_oem7_msgs::msg::INSPVA;
-using novatel_oem7_msgs::msg::INSPVAX;
+using art_novatel_oem7_msgs::msg::PPPPOS;
+using art_novatel_oem7_msgs::msg::BESTPOS;
+using art_novatel_oem7_msgs::msg::BESTVEL;
+using art_novatel_oem7_msgs::msg::BESTUTM;
+using art_novatel_oem7_msgs::msg::BESTGNSSPOS;
+using art_novatel_oem7_msgs::msg::BESTGNSSVEL;
+using art_novatel_oem7_msgs::msg::INSPVA;
+using art_novatel_oem7_msgs::msg::INSPVAX;
 
 
 
@@ -170,8 +170,8 @@ namespace novatel_oem7_driver
    */
   ValueRelation
   GetOem7MessageTimeRelation(
-      novatel_oem7_msgs::msg::Oem7Header msg_hdr_1,
-      novatel_oem7_msgs::msg::Oem7Header msg_hdr_2)
+      art_novatel_oem7_msgs::msg::Oem7Header msg_hdr_1,
+      art_novatel_oem7_msgs::msg::Oem7Header msg_hdr_2)
   {
     if(msg_hdr_1.gps_week_number > msg_hdr_2.gps_week_number)
       return REL_GT;
@@ -319,28 +319,28 @@ namespace novatel_oem7_driver
 
     void publishBESTUTM(Oem7RawMessageIf::ConstPtr msg)
     {
-        std::shared_ptr<novatel_oem7_msgs::msg::BESTUTM> bestutm;
+        std::shared_ptr<art_novatel_oem7_msgs::msg::BESTUTM> bestutm;
         MakeROSMessage(msg, bestutm);
         BESTUTM_pub_->publish(bestutm);
     }
 
     void publishBESTGNSSPOS(Oem7RawMessageIf::ConstPtr msg)
     {
-        std::shared_ptr<novatel_oem7_msgs::msg::BESTPOS> bestgnsspos;
+        std::shared_ptr<art_novatel_oem7_msgs::msg::BESTPOS> bestgnsspos;
         MakeROSMessage(msg, bestgnsspos);
         BESTGNSSPOS_pub_->publish(bestgnsspos);
     }
 
     void publishBESTGNSSVEL(Oem7RawMessageIf::ConstPtr msg)
     {
-        std::shared_ptr<novatel_oem7_msgs::msg::BESTVEL> bestgnssvel;
+        std::shared_ptr<art_novatel_oem7_msgs::msg::BESTVEL> bestgnssvel;
         MakeROSMessage(msg, bestgnssvel);
         BESTGNSSVEL_pub_->publish(bestgnssvel);
     }
 
     void publishPPPPOS(Oem7RawMessageIf::ConstPtr msg)
     {
-        std::shared_ptr<novatel_oem7_msgs::msg::PPPPOS> ppppos;
+        std::shared_ptr<art_novatel_oem7_msgs::msg::PPPPOS> ppppos;
         MakeROSMessage(msg, ppppos);
         PPPPOS_pub_->publish(ppppos);
     }
@@ -406,7 +406,7 @@ namespace novatel_oem7_driver
                             bestvel_->nov_header.gps_week_milliseconds);
         }
 
-        if(bestvel_->vel_type.type == novatel_oem7_msgs::msg::PositionOrVelocityType::DOPPLER_VELOCITY)
+        if(bestvel_->vel_type.type == art_novatel_oem7_msgs::msg::PositionOrVelocityType::DOPPLER_VELOCITY)
         {
           gpsfix_->status.motion_source |= GPSStatus::SOURCE_DOPPLER;
         }
@@ -624,42 +624,42 @@ namespace novatel_oem7_driver
 
       switch(bestpos->pos_type.type)
       {
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::PSRDIFF:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PSRDIFF:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::L1_FLOAT:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::NARROW_FLOAT:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::L1_INT:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::WIDE_INT:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::NARROW_INT:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::RTK_DIRECT_INS:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::INS_RTKFLOAT:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::INS_RTKFIXED:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::PSRDIFF:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PSRDIFF:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::L1_FLOAT:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::NARROW_FLOAT:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::L1_INT:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::WIDE_INT:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::NARROW_INT:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::RTK_DIRECT_INS:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::INS_RTKFLOAT:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::INS_RTKFIXED:
           return GPSStatus::STATUS_DGPS_FIX;
 
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::FIXEDPOS:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::FIXEDHEIGHT:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::DOPPLER_VELOCITY:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::SINGLE:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PSRSP:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::PROPAGATED:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::OPERATIONAL:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::WARNING:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::OUT_OF_BOUNDS:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::FIXEDPOS:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::FIXEDHEIGHT:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::DOPPLER_VELOCITY:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::SINGLE:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PSRSP:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::PROPAGATED:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::OPERATIONAL:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::WARNING:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::OUT_OF_BOUNDS:
           return GPSStatus::STATUS_FIX;
 
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::WAAS:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::INS_SBAS:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::PPP_CONVERGING:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::PPP:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PPP_CONVERGING:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PPP:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::PPP_BASIC_CONVERGING:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::PPP_BASIC:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PPP_BASIC_CONVERGING:
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PPP_BASIC:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::WAAS:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::INS_SBAS:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::PPP_CONVERGING:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::PPP:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PPP_CONVERGING:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PPP:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::PPP_BASIC_CONVERGING:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::PPP_BASIC:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PPP_BASIC_CONVERGING:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::INS_PPP_BASIC:
           return GPSStatus::STATUS_SBAS_FIX;
 
-        case novatel_oem7_msgs::msg::PositionOrVelocityType::NONE:
+        case art_novatel_oem7_msgs::msg::PositionOrVelocityType::NONE:
           return GPSStatus::STATUS_NO_FIX;
 
         default:
@@ -847,7 +847,7 @@ namespace novatel_oem7_driver
 
       if(msg->getMessageId() == INSPVAX_OEM7_MSGID)
       {
-        MakeROSMessage<novatel_oem7_msgs::msg::INSPVAX>(msg, inspvax_);
+        MakeROSMessage<art_novatel_oem7_msgs::msg::INSPVAX>(msg, inspvax_);
       }
 
       if(msg->getMessageId() == PSRDOP2_OEM7_MSGID)

--- a/src/novatel_oem7_driver/src/ins_handler.cpp
+++ b/src/novatel_oem7_driver/src/ins_handler.cpp
@@ -35,12 +35,12 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include "sensor_msgs/msg/imu.hpp"
 
-#include "novatel_oem7_msgs/msg/corrimu.hpp"
-#include "novatel_oem7_msgs/msg/imuratecorrimu.hpp"
-#include "novatel_oem7_msgs/msg/insstdev.hpp"
-#include "novatel_oem7_msgs/msg/insconfig.hpp"
-#include "novatel_oem7_msgs/msg/inspva.hpp"
-#include "novatel_oem7_msgs/msg/inspvax.hpp"
+#include "art_novatel_oem7_msgs/msg/corrimu.hpp"
+#include "art_novatel_oem7_msgs/msg/imuratecorrimu.hpp"
+#include "art_novatel_oem7_msgs/msg/insstdev.hpp"
+#include "art_novatel_oem7_msgs/msg/insconfig.hpp"
+#include "art_novatel_oem7_msgs/msg/inspva.hpp"
+#include "art_novatel_oem7_msgs/msg/inspvax.hpp"
 
 #include <oem7_ros_publisher.hpp>
 #include <driver_parameter.hpp>
@@ -69,15 +69,15 @@ namespace novatel_oem7_driver
 
     std::unique_ptr<Oem7RosPublisher<sensor_msgs::msg::Imu>>                   imu_pub_;
     std::unique_ptr<Oem7RosPublisher<sensor_msgs::msg::Imu>>                   raw_imu_pub_;
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::CORRIMU>>         corrimu_pub_;
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::INSSTDEV>>        insstdev_pub_;
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::INSPVAX>>         inspvax_pub_;
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::INSCONFIG>>       insconfig_pub_;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::CORRIMU>>         corrimu_pub_;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::INSSTDEV>>        insstdev_pub_;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::INSPVAX>>         inspvax_pub_;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::INSCONFIG>>       insconfig_pub_;
 
 
-    std::shared_ptr<novatel_oem7_msgs::msg::INSPVA>   inspva_;
-    std::shared_ptr<novatel_oem7_msgs::msg::CORRIMU>  corrimu_;
-    std::shared_ptr<novatel_oem7_msgs::msg::INSSTDEV> insstdev_;
+    std::shared_ptr<art_novatel_oem7_msgs::msg::INSPVA>   inspva_;
+    std::shared_ptr<art_novatel_oem7_msgs::msg::CORRIMU>  corrimu_;
+    std::shared_ptr<art_novatel_oem7_msgs::msg::INSSTDEV> insstdev_;
 
     oem7_imu_rate_t imu_rate_;                    ///< IMU output rate
     double          imu_raw_gyro_scale_factor_;   ///< IMU-specific raw gyroscope scaling
@@ -106,7 +106,7 @@ namespace novatel_oem7_driver
 
     void processInsConfigMsg(Oem7RawMessageIf::ConstPtr msg)
     {
-      std::shared_ptr<novatel_oem7_msgs::msg::INSCONFIG> insconfig;
+      std::shared_ptr<art_novatel_oem7_msgs::msg::INSCONFIG> insconfig;
       MakeROSMessage(msg, insconfig);
       insconfig_pub_->publish(insconfig);
 
@@ -152,7 +152,7 @@ namespace novatel_oem7_driver
 
     void publishInsPVAXMsg(Oem7RawMessageIf::ConstPtr msg)
     {
-      std::shared_ptr<novatel_oem7_msgs::msg::INSPVAX> inspvax;
+      std::shared_ptr<art_novatel_oem7_msgs::msg::INSPVAX> inspvax;
       MakeROSMessage(msg, inspvax);
 
       inspvax_pub_->publish(inspvax);
@@ -282,10 +282,10 @@ namespace novatel_oem7_driver
 
       imu_pub_       = std::make_unique<Oem7RosPublisher<sensor_msgs::msg::Imu>>(            "IMU",       node);
       raw_imu_pub_   = std::make_unique<Oem7RosPublisher<sensor_msgs::msg::Imu>>(            "RAWIMU",    node);
-      corrimu_pub_   = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::CORRIMU>>(  "CORRIMU",   node);
-      insstdev_pub_  = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::INSSTDEV>>( "INSSTDEV",  node);
-      inspvax_pub_   = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::INSPVAX>>(  "INSPVAX",   node);
-      insconfig_pub_ = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::INSCONFIG>>("INSCONFIG", node);
+      corrimu_pub_   = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::CORRIMU>>(  "CORRIMU",   node);
+      insstdev_pub_  = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::INSSTDEV>>( "INSSTDEV",  node);
+      inspvax_pub_   = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::INSPVAX>>(  "INSPVAX",   node);
+      insconfig_pub_ = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::INSCONFIG>>("INSCONFIG", node);
 
       DriverParameter<int> imu_rate_p("oem7_imu_rate", 0, *node_);
       imu_rate_ = imu_rate_p.value();

--- a/src/novatel_oem7_driver/src/odometry_handler.cpp
+++ b/src/novatel_oem7_driver/src/odometry_handler.cpp
@@ -40,8 +40,8 @@
 #include "gps_msgs/msg/gps_fix.hpp"
 #include "sensor_msgs/msg/imu.hpp"
 
-#include "novatel_oem7_msgs/msg/inspva.hpp"
-#include "novatel_oem7_msgs/msg/inspvax.hpp"
+#include "art_novatel_oem7_msgs/msg/inspva.hpp"
+#include "art_novatel_oem7_msgs/msg/inspvax.hpp"
 
 #include <GeographicLib/UTMUPS.hpp>
 
@@ -51,8 +51,8 @@ using gps_msgs::msg::GPSFix;
 using gps_msgs::msg::GPSStatus;
 using nav_msgs::msg::Odometry;
 
-using novatel_oem7_msgs::msg::INSPVA;
-using novatel_oem7_msgs::msg::INSPVAX;
+using art_novatel_oem7_msgs::msg::INSPVA;
+using art_novatel_oem7_msgs::msg::INSPVAX;
 
 using tf2_ros::TransformBroadcaster;
 

--- a/src/novatel_oem7_driver/src/oem7_driver_util.hpp
+++ b/src/novatel_oem7_driver/src/oem7_driver_util.hpp
@@ -23,7 +23,7 @@
 ////////////////////////////////////////////////////////////////////////////////
 
 #include <stdint.h>
-#include "novatel_oem7_msgs/msg/oem7_header.hpp"
+#include "art_novatel_oem7_msgs/msg/oem7_header.hpp"
 
 
 namespace novatel_oem7_driver
@@ -41,7 +41,7 @@ namespace novatel_oem7_driver
    * Covers GPSTime obtained from header to milliseconds.
    * @return milliseconds
    */
-  static inline int64_t GPSTimeToMsec(const novatel_oem7_msgs::msg::Oem7Header& hdr)
+  static inline int64_t GPSTimeToMsec(const art_novatel_oem7_msgs::msg::Oem7Header& hdr)
   {
     return GPSTimeToMsec(hdr.gps_week_number, hdr.gps_week_milliseconds);
   }

--- a/src/novatel_oem7_driver/src/oem7_message_node.cpp
+++ b/src/novatel_oem7_driver/src/oem7_message_node.cpp
@@ -31,8 +31,8 @@
 
 #include <boost/asio.hpp>
 
-#include "novatel_oem7_msgs/srv/oem7_abascii_cmd.hpp"
-#include "novatel_oem7_msgs/msg/oem7_raw_msg.h"
+#include "art_novatel_oem7_msgs/srv/oem7_abascii_cmd.hpp"
+#include "art_novatel_oem7_msgs/msg/oem7_raw_msg.h"
 
 #include <pluginlib/class_loader.hpp>
 
@@ -45,7 +45,7 @@
 #include <message_handler.hpp>
 #include <driver_parameter.hpp>
 
-#include "novatel_oem7_msgs/msg/oem7_header.hpp"
+#include "art_novatel_oem7_msgs/msg/oem7_header.hpp"
 
 
 namespace novatel_oem7_driver
@@ -75,14 +75,14 @@ namespace novatel_oem7_driver
 
     double publish_delay_sec_; ///< Delay after publishing each message; used to throttle output with static data sources.
 
-    Oem7RosPublisher<novatel_oem7_msgs::msg::Oem7RawMsg> oem7rawmsg_pub_; ///< Publishes raw Oem7 messages.
+    Oem7RosPublisher<art_novatel_oem7_msgs::msg::Oem7RawMsg> oem7rawmsg_pub_; ///< Publishes raw Oem7 messages.
     bool publish_unknown_oem7raw_; ///< Publish all unknown messages to 'Oem7Raw'
 
 
     rclcpp::CallbackGroup::SharedPtr msg_service_cb_grp_; ///< Message service callbacks
     rclcpp::CallbackGroup::SharedPtr cmd_service_cb_grp_; ///< Command service callbacks
 
-    rclcpp::Service<novatel_oem7_msgs::srv::Oem7AbasciiCmd>::SharedPtr oem7_abascii_cmd_srv_;
+    rclcpp::Service<art_novatel_oem7_msgs::srv::Oem7AbasciiCmd>::SharedPtr oem7_abascii_cmd_srv_;
 
     // Command service
 
@@ -218,8 +218,8 @@ namespace novatel_oem7_driver
      */
     void
     serviceOem7AbasciiCb(
-          const std::shared_ptr<novatel_oem7_msgs::srv::Oem7AbasciiCmd::Request>  req,
-                std::shared_ptr<novatel_oem7_msgs::srv::Oem7AbasciiCmd::Response> rsp)
+          const std::shared_ptr<art_novatel_oem7_msgs::srv::Oem7AbasciiCmd::Request>  req,
+                std::shared_ptr<art_novatel_oem7_msgs::srv::Oem7AbasciiCmd::Response> rsp)
     {
       issueOem7AbasciiCmd(req->cmd, rsp->rsp);
     }
@@ -311,7 +311,7 @@ namespace novatel_oem7_driver
 
     void publishOem7RawMsg(Oem7RawMessageIf::ConstPtr raw_msg)
     {
-        novatel_oem7_msgs::msg::Oem7RawMsg::SharedPtr oem7_raw_msg = std::make_shared<novatel_oem7_msgs::msg::Oem7RawMsg>();
+        art_novatel_oem7_msgs::msg::Oem7RawMsg::SharedPtr oem7_raw_msg = std::make_shared<art_novatel_oem7_msgs::msg::Oem7RawMsg>();
         oem7_raw_msg->message_data.insert(
                                         oem7_raw_msg->message_data.end(),
                                         raw_msg->getMessageData(0),
@@ -463,7 +463,7 @@ namespace novatel_oem7_driver
       // Now that all internal init commands have been issued, allow external commands:
       static rmw_qos_profile_t qos = rmw_qos_profile_default;
       qos.depth = 20;
-      oem7_abascii_cmd_srv_ = create_service<novatel_oem7_msgs::srv::Oem7AbasciiCmd>(
+      oem7_abascii_cmd_srv_ = create_service<art_novatel_oem7_msgs::srv::Oem7AbasciiCmd>(
                                "Oem7Cmd",
                                std::bind(
                                       &Oem7MessageNode::serviceOem7AbasciiCb,

--- a/src/novatel_oem7_driver/src/oem7_message_util.cpp
+++ b/src/novatel_oem7_driver/src/oem7_message_util.cpp
@@ -58,7 +58,7 @@ namespace novatel_oem7_driver
    */
   void getOem7Header(
       const Oem7RawMessageIf::ConstPtr& raw_msg,
-      novatel_oem7_msgs::msg::Oem7Header& hdr
+      art_novatel_oem7_msgs::msg::Oem7Header& hdr
       )
   {
     const Oem7MessageHeaderMem* hdr_mem = reinterpret_cast<const Oem7MessageHeaderMem*>(raw_msg->getMessageData(0));
@@ -75,13 +75,13 @@ namespace novatel_oem7_driver
 
   void getOem7ShortHeader(
       const Oem7RawMessageIf::ConstPtr& raw_msg,  ///< [in] Raw binary message
-      novatel_oem7_msgs::msg::Oem7Header& hdr     ///< [out] Oem7 Message Header
+      art_novatel_oem7_msgs::msg::Oem7Header& hdr     ///< [out] Oem7 Message Header
       )
   {
     const Oem7MessgeShortHeaderMem* hdr_mem = reinterpret_cast<const Oem7MessgeShortHeaderMem*>(raw_msg->getMessageData(0));
 
     hdr.message_id             = hdr_mem->message_id;
-    hdr.message_type           = novatel_oem7_msgs::msg::Oem7Header::OEM7MSGTYPE_LOG; // Always log
+    hdr.message_type           = art_novatel_oem7_msgs::msg::Oem7Header::OEM7MSGTYPE_LOG; // Always log
     hdr.sequence_number        = 0; // Not available; assume it's a single log.
     hdr.time_status            = GPS_REFTIME_STATUS_UNKNOWN;
     hdr.gps_week_number        = hdr_mem->gps_week;

--- a/src/novatel_oem7_driver/src/oem7_ros_messages.cpp
+++ b/src/novatel_oem7_driver/src/oem7_ros_messages.cpp
@@ -33,26 +33,26 @@
 #include "novatel_oem7_driver/oem7_message_util.hpp"
 
 
-#include "novatel_oem7_msgs/msg/heading2.hpp"
-#include "novatel_oem7_msgs/msg/bestpos.hpp"
-#include "novatel_oem7_msgs/msg/bestvel.hpp"
-#include "novatel_oem7_msgs/msg/bestutm.hpp"
-#include "novatel_oem7_msgs/msg/bestgnsspos.hpp"
-#include "novatel_oem7_msgs/msg/bestgnssvel.hpp"
-#include "novatel_oem7_msgs/msg/ppppos.hpp"
-#include "novatel_oem7_msgs/msg/inspva.hpp"
-#include "novatel_oem7_msgs/msg/inspvax.hpp"
-#include "novatel_oem7_msgs/msg/insconfig.hpp"
-#include "novatel_oem7_msgs/msg/insstdev.hpp"
-#include "novatel_oem7_msgs/msg/corrimu.hpp"
-#include "novatel_oem7_msgs/msg/rxstatus.hpp"
-#include "novatel_oem7_msgs/msg/terrastarinfo.hpp"
-#include "novatel_oem7_msgs/msg/terrastarstatus.hpp"
-#include "novatel_oem7_msgs/msg/rangeobservation.hpp"
-#include "novatel_oem7_msgs/msg/range.hpp"
-#include "novatel_oem7_msgs/msg/time.hpp"
-#include "novatel_oem7_msgs/msg/masterpos.hpp"
-#include "novatel_oem7_msgs/msg/roverpos.hpp"
+#include "art_novatel_oem7_msgs/msg/heading2.hpp"
+#include "art_novatel_oem7_msgs/msg/bestpos.hpp"
+#include "art_novatel_oem7_msgs/msg/bestvel.hpp"
+#include "art_novatel_oem7_msgs/msg/bestutm.hpp"
+#include "art_novatel_oem7_msgs/msg/bestgnsspos.hpp"
+#include "art_novatel_oem7_msgs/msg/bestgnssvel.hpp"
+#include "art_novatel_oem7_msgs/msg/ppppos.hpp"
+#include "art_novatel_oem7_msgs/msg/inspva.hpp"
+#include "art_novatel_oem7_msgs/msg/inspvax.hpp"
+#include "art_novatel_oem7_msgs/msg/insconfig.hpp"
+#include "art_novatel_oem7_msgs/msg/insstdev.hpp"
+#include "art_novatel_oem7_msgs/msg/corrimu.hpp"
+#include "art_novatel_oem7_msgs/msg/rxstatus.hpp"
+#include "art_novatel_oem7_msgs/msg/terrastarinfo.hpp"
+#include "art_novatel_oem7_msgs/msg/terrastarstatus.hpp"
+#include "art_novatel_oem7_msgs/msg/rangeobservation.hpp"
+#include "art_novatel_oem7_msgs/msg/range.hpp"
+#include "art_novatel_oem7_msgs/msg/time.hpp"
+#include "art_novatel_oem7_msgs/msg/masterpos.hpp"
+#include "art_novatel_oem7_msgs/msg/roverpos.hpp"
 
 
 #define arr_size(_arr_) (sizeof(_arr_) / sizeof(_arr_[0]))
@@ -67,7 +67,7 @@ void
 SetOem7Header(
     const Oem7RawMessageIf::ConstPtr& msg, ///< in: raw message
     const std::string& name, ///< message name
-    novatel_oem7_msgs::msg::Oem7Header::Type& oem7_hdr ///< header to populate
+    art_novatel_oem7_msgs::msg::Oem7Header::Type& oem7_hdr ///< header to populate
     )
 {
   getOem7Header(msg, oem7_hdr);
@@ -81,7 +81,7 @@ void
 SetOem7ShortHeader(
     const Oem7RawMessageIf::ConstPtr& msg, ///< in: short raw message
     const std::string& name, ///< message name
-    novatel_oem7_msgs::msg::Oem7Header::Type& oem7_hdr ///< header to populate
+    art_novatel_oem7_msgs::msg::Oem7Header::Type& oem7_hdr ///< header to populate
     )
 {
   getOem7ShortHeader(msg, oem7_hdr);
@@ -92,14 +92,14 @@ SetOem7ShortHeader(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::HEADING2>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::HEADING2>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::HEADING2>& heading2)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::HEADING2>& heading2)
 {
   assert(msg->getMessageId() == HEADING2_OEM7_MSGID);
 
   const HEADING2Mem* mem = reinterpret_cast<const HEADING2Mem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  heading2.reset(new novatel_oem7_msgs::msg::HEADING2);
+  heading2.reset(new art_novatel_oem7_msgs::msg::HEADING2);
 
   heading2->sol_status.status     = mem->sol_status;
   heading2->pos_type.type         = mem->pos_type;
@@ -126,14 +126,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::HEADING2>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::BESTPOS>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::BESTPOS>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::BESTPOS>& bestpos)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::BESTPOS>& bestpos)
 {
   assert(msg->getMessageId() == BESTPOS_OEM7_MSGID);
 
   const BESTPOSMem* bp = reinterpret_cast<const BESTPOSMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  bestpos.reset(new novatel_oem7_msgs::msg::BESTPOS);
+  bestpos.reset(new art_novatel_oem7_msgs::msg::BESTPOS);
 
   bestpos->sol_status.status      = bp->sol_stat;
   bestpos->pos_type.type          = bp->pos_type;
@@ -163,14 +163,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::BESTPOS>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::BESTVEL>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::BESTVEL>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::BESTVEL>& bestvel)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::BESTVEL>& bestvel)
 {
   assert(msg->getMessageId() == BESTVEL_OEM7_MSGID);
 
   const BESTVELMem* bv = reinterpret_cast<const BESTVELMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  bestvel.reset(new novatel_oem7_msgs::msg::BESTVEL);
+  bestvel.reset(new art_novatel_oem7_msgs::msg::BESTVEL);
 
   bestvel->sol_status.status = bv->sol_stat;
   bestvel->vel_type.type     = bv->vel_type;
@@ -187,14 +187,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::BESTVEL>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::BESTUTM>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::BESTUTM>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::BESTUTM>& bestutm)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::BESTUTM>& bestutm)
 {
     assert(msg->getMessageId() == BESTUTM_OEM7_MSGID);
 
     const BESTUTMMem* mem = reinterpret_cast<const BESTUTMMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-    bestutm.reset(new novatel_oem7_msgs::msg::BESTUTM);
+    bestutm.reset(new art_novatel_oem7_msgs::msg::BESTUTM);
 
     bestutm->pos_type.type          = mem->pos_type;;
     bestutm->lon_zone_number        = mem->lon_zone_number;
@@ -225,14 +225,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::BESTUTM>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::BESTGNSSPOS>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::BESTGNSSPOS>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::BESTGNSSPOS>& bestgnsspos)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::BESTGNSSPOS>& bestgnsspos)
 {
   assert(msg->getMessageId() == BESTGNSSPOS_OEM7_MSGID);
 
   const BESTGNSSPOSMem* bgp = reinterpret_cast<const BESTGNSSPOSMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  bestgnsspos.reset(new novatel_oem7_msgs::msg::BESTGNSSPOS);
+  bestgnsspos.reset(new art_novatel_oem7_msgs::msg::BESTGNSSPOS);
 
   bestgnsspos->sol_status.status      = bgp->sol_stat;
   bestgnsspos->pos_type.type          = bgp->pos_type;
@@ -262,14 +262,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::BESTGNSSPOS>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::BESTGNSSVEL>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::BESTGNSSVEL>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::BESTGNSSVEL>& bestgnssvel)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::BESTGNSSVEL>& bestgnssvel)
 {
   assert(msg->getMessageId() == BESTGNSSVEL_OEM7_MSGID);
 
   const BESTGNSSVELMem* bv = reinterpret_cast<const BESTGNSSVELMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  bestgnssvel.reset(new novatel_oem7_msgs::msg::BESTGNSSVEL);
+  bestgnssvel.reset(new art_novatel_oem7_msgs::msg::BESTGNSSVEL);
 
   bestgnssvel->sol_status.status = bv->sol_stat;
   bestgnssvel->vel_type.type     = bv->vel_type;
@@ -286,14 +286,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::BESTGNSSVEL>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::INSPVA>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::INSPVA>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::INSPVA>& pva)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::INSPVA>& pva)
 {
   assert(msg->getMessageId() == INSPVAS_OEM7_MSGID);
 
   const INSPVASmem* pvamem = reinterpret_cast<const INSPVASmem*>(msg->getMessageData(OEM7_BINARY_MSG_SHORT_HDR_LEN));
-  pva.reset(new novatel_oem7_msgs::msg::INSPVA);
+  pva.reset(new art_novatel_oem7_msgs::msg::INSPVA);
 
   pva->latitude        =     pvamem->latitude;
   pva->longitude       =     pvamem->longitude;
@@ -313,15 +313,15 @@ MakeROSMessage<novatel_oem7_msgs::msg::INSPVA>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::INSCONFIG>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::INSCONFIG>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::INSCONFIG>& insconfig)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::INSCONFIG>& insconfig)
 {
   assert(msg->getMessageId()== INSCONFIG_OEM7_MSGID);
 
   const INSCONFIG_FixedMem* insconfigmem =
       reinterpret_cast<const INSCONFIG_FixedMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  insconfig.reset(new novatel_oem7_msgs::msg::INSCONFIG);
+  insconfig.reset(new art_novatel_oem7_msgs::msg::INSCONFIG);
 
   insconfig->imu_type                         = insconfigmem->imu_type;
   insconfig->mapping                          = insconfigmem->mapping;
@@ -359,7 +359,7 @@ MakeROSMessage<novatel_oem7_msgs::msg::INSCONFIG>(
              idx++)
   {
     const INSCONFIG_TranslationMem* trmem = Get_INSCONFIG_Translation(insconfigmem, idx);
-    novatel_oem7_msgs::msg::Translation& tr = insconfig->translations[idx];
+    art_novatel_oem7_msgs::msg::Translation& tr = insconfig->translations[idx];
 
     tr.translation.type    = trmem->translation;
     tr.frame.frame         = trmem->frame;
@@ -378,7 +378,7 @@ MakeROSMessage<novatel_oem7_msgs::msg::INSCONFIG>(
              idx++)
   {
     const INSCONFIG_RotationMem* rtmem = Get_INSCONFIG_Rotation(insconfigmem, idx);
-    novatel_oem7_msgs::msg::Rotation& rt = insconfig->rotations[idx];
+    art_novatel_oem7_msgs::msg::Rotation& rt = insconfig->rotations[idx];
     rt.rotation.offset         = rtmem->rotation;
     rt.frame.frame             = rtmem->frame;
     rt.x_rotation              = rtmem->x_rotation;
@@ -397,14 +397,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::INSCONFIG>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::INSPVAX>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::INSPVAX>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::INSPVAX>& inspvax)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::INSPVAX>& inspvax)
 {
   assert(msg->getMessageId() == INSPVAX_OEM7_MSGID);
 
   const INSPVAXMem* mem = reinterpret_cast<const INSPVAXMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  inspvax.reset(new novatel_oem7_msgs::msg::INSPVAX);
+  inspvax.reset(new art_novatel_oem7_msgs::msg::INSPVAX);
 
   inspvax->ins_status.status        = mem->ins_status;
   inspvax->pos_type.type            = mem->pos_type;
@@ -437,14 +437,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::INSPVAX>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::INSSTDEV>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::INSSTDEV>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::INSSTDEV>& insstdev)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::INSSTDEV>& insstdev)
 {
   assert(msg->getMessageId() == INSSTDEV_OEM7_MSGID);
 
   const INSSTDEVMem* raw = reinterpret_cast<const INSSTDEVMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  insstdev.reset(new novatel_oem7_msgs::msg::INSSTDEV);
+  insstdev.reset(new art_novatel_oem7_msgs::msg::INSSTDEV);
 
   insstdev->latitude_stdev         = raw->latitude_stdev;
   insstdev->longitude_stdev        = raw->longitude_stdev;
@@ -467,11 +467,11 @@ MakeROSMessage<novatel_oem7_msgs::msg::INSSTDEV>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::CORRIMU>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::CORRIMU>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::CORRIMU>& corrimu)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::CORRIMU>& corrimu)
 {
-  corrimu.reset(new novatel_oem7_msgs::msg::CORRIMU);
+  corrimu.reset(new art_novatel_oem7_msgs::msg::CORRIMU);
 
   if(msg->getMessageId() == CORRIMUS_OEM7_MSGID)
   {
@@ -507,14 +507,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::CORRIMU>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::TIME>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::TIME>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::TIME>& time)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::TIME>& time)
 {
   assert(msg->getMessageId()== TIME_OEM7_MSGID);
 
   const TIMEMem* mem = reinterpret_cast<const TIMEMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  time.reset(new novatel_oem7_msgs::msg::TIME);
+  time.reset(new art_novatel_oem7_msgs::msg::TIME);
 
   time->clock_status  = mem->clock_status;
   time->offset        = mem->offset;
@@ -534,14 +534,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::TIME>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::RXSTATUS>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::RXSTATUS>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::RXSTATUS>& rxstatus)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::RXSTATUS>& rxstatus)
 {
   assert(msg->getMessageId() == RXSTATUS_OEM7_MSGID);
 
   const RXSTATUSMem* mem = reinterpret_cast<const RXSTATUSMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  rxstatus.reset(new novatel_oem7_msgs::msg::RXSTATUS);
+  rxstatus.reset(new art_novatel_oem7_msgs::msg::RXSTATUS);
 
   rxstatus->error              = mem->error;
   rxstatus->num_status_codes   = mem->num_status_codes;
@@ -573,14 +573,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::RXSTATUS>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::PPPPOS>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::PPPPOS>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::PPPPOS>& ppppos)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::PPPPOS>& ppppos)
 {
   assert(msg->getMessageId() == PPPPOS_OEM7_MSGID);
 
   const PPPPOSMem* pp = reinterpret_cast<const PPPPOSMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  ppppos.reset(new novatel_oem7_msgs::msg::PPPPOS);
+  ppppos.reset(new art_novatel_oem7_msgs::msg::PPPPOS);
 
   ppppos->sol_status.status      = pp->sol_stat;
   ppppos->pos_type.type          = pp->pos_type;
@@ -610,14 +610,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::PPPPOS>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::TERRASTARINFO>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::TERRASTARINFO>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::TERRASTARINFO>& terrastarinfo)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::TERRASTARINFO>& terrastarinfo)
 {
   assert(msg->getMessageId() == TERRASTARINFO_OEM7_MSGID);
 
   const TERRASTARINFOMem* tsi = reinterpret_cast<const TERRASTARINFOMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  terrastarinfo.reset(new novatel_oem7_msgs::msg::TERRASTARINFO);
+  terrastarinfo.reset(new art_novatel_oem7_msgs::msg::TERRASTARINFO);
 
   terrastarinfo->product_activation_code        = tsi->product_activation_code;
   terrastarinfo->sub_type.type                  = tsi->sub_type;
@@ -636,14 +636,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::TERRASTARINFO>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::TERRASTARSTATUS>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::TERRASTARSTATUS>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::TERRASTARSTATUS>& terrastarstatus)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::TERRASTARSTATUS>& terrastarstatus)
 {
   assert(msg->getMessageId() == TERRASTARSTATUS_OEM7_MSGID);
 
   const TERRASTARSTATUSMem* tss = reinterpret_cast<const TERRASTARSTATUSMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  terrastarstatus.reset(new novatel_oem7_msgs::msg::TERRASTARSTATUS);
+  terrastarstatus.reset(new art_novatel_oem7_msgs::msg::TERRASTARSTATUS);
 
   terrastarstatus->access_status.status      = tss->access_status;
   terrastarstatus->sync_state.state          = tss->sync_state;
@@ -657,18 +657,18 @@ MakeROSMessage<novatel_oem7_msgs::msg::TERRASTARSTATUS>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::RANGE>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::RANGE>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::RANGE>& range)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::RANGE>& range)
 {
   assert(msg->getMessageId() == RANGE_OEM7_MSGID);
 
   const RangeMem* rmem = reinterpret_cast<const RangeMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  range.reset(new novatel_oem7_msgs::msg::RANGE);
+  range.reset(new art_novatel_oem7_msgs::msg::RANGE);
   range->num_obs = rmem->num_obs;
   range->obs.reserve(range->num_obs);
   static const size_t obs_offset = OEM7_BINARY_MSG_HDR_LEN + sizeof(uint32_t);
-  novatel_oem7_msgs::msg::RANGEOBSERVATION obs_msg;
+  art_novatel_oem7_msgs::msg::RANGEOBSERVATION obs_msg;
   for (uint32_t i = 0; i < range->num_obs; i++)
   {
     const RangeObsMem* obs_mem = reinterpret_cast<const RangeObsMem*>(msg->getMessageData(obs_offset + (sizeof(RangeObsMem) * i)));
@@ -690,14 +690,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::RANGE>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::MASTERPOS>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::MASTERPOS>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::MASTERPOS>& masterpos)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::MASTERPOS>& masterpos)
 {
   assert(msg->getMessageId() == MASTERPOS_OEM7_MSGID);
 
   const MASTERPOSMem* mp = reinterpret_cast<const MASTERPOSMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  masterpos.reset(new novatel_oem7_msgs::msg::MASTERPOS);
+  masterpos.reset(new art_novatel_oem7_msgs::msg::MASTERPOS);
 
   masterpos->sol_status.status      = mp->sol_stat;
   masterpos->pos_type.type          = mp->pos_type;
@@ -723,14 +723,14 @@ MakeROSMessage<novatel_oem7_msgs::msg::MASTERPOS>(
 
 template<>
 void
-MakeROSMessage<novatel_oem7_msgs::msg::ROVERPOS>(
+MakeROSMessage<art_novatel_oem7_msgs::msg::ROVERPOS>(
     const Oem7RawMessageIf::ConstPtr& msg,
-    std::shared_ptr<novatel_oem7_msgs::msg::ROVERPOS>& roverpos)
+    std::shared_ptr<art_novatel_oem7_msgs::msg::ROVERPOS>& roverpos)
 {
   assert(msg->getMessageId() == ROVERPOS_OEM7_MSGID);
 
   const ROVERPOSMem* rp = reinterpret_cast<const ROVERPOSMem*>(msg->getMessageData(OEM7_BINARY_MSG_HDR_LEN));
-  roverpos.reset(new novatel_oem7_msgs::msg::ROVERPOS);
+  roverpos.reset(new art_novatel_oem7_msgs::msg::ROVERPOS);
 
   roverpos->sol_status.status      = rp->sol_stat;
   roverpos->pos_type.type          = rp->pos_type;
@@ -755,75 +755,75 @@ MakeROSMessage<novatel_oem7_msgs::msg::ROVERPOS>(
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&, std::shared_ptr<novatel_oem7_msgs::msg::BESTPOS>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&, std::shared_ptr<art_novatel_oem7_msgs::msg::BESTPOS>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::BESTVEL>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::BESTVEL>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::BESTUTM>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::BESTUTM>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::BESTGNSSPOS>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::BESTGNSSPOS>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::BESTGNSSVEL>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::BESTGNSSVEL>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::INSPVA>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::INSPVA>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&, std::shared_ptr<novatel_oem7_msgs::msg::INSPVAX>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&, std::shared_ptr<art_novatel_oem7_msgs::msg::INSPVAX>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::INSCONFIG>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::INSCONFIG>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::INSSTDEV>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::INSSTDEV>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::CORRIMU>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::CORRIMU>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::TIME>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::TIME>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::RXSTATUS>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::RXSTATUS>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::PPPPOS>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::PPPPOS>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::TERRASTARSTATUS>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::TERRASTARSTATUS>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::TERRASTARINFO>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::TERRASTARINFO>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::RANGE>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::RANGE>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::MASTERPOS>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::MASTERPOS>&);
 
 template
 void
-MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<novatel_oem7_msgs::msg::ROVERPOS>&);
+MakeROSMessage(const Oem7RawMessageIf::ConstPtr&,  std::shared_ptr<art_novatel_oem7_msgs::msg::ROVERPOS>&);
 
 
 //---------------------------------------------------------------------------------------------------------------

--- a/src/novatel_oem7_driver/src/range_handler.cpp
+++ b/src/novatel_oem7_driver/src/range_handler.cpp
@@ -33,9 +33,9 @@
 
 #include <oem7_ros_publisher.hpp>
 
-#include "novatel_oem7_msgs/msg/range.hpp"
+#include "art_novatel_oem7_msgs/msg/range.hpp"
 
-using novatel_oem7_msgs::msg::RANGE;
+using art_novatel_oem7_msgs::msg::RANGE;
 
 
 namespace novatel_oem7_driver

--- a/src/novatel_oem7_driver/src/receiverstatus_handler.cpp
+++ b/src/novatel_oem7_driver/src/receiverstatus_handler.cpp
@@ -31,9 +31,9 @@
 
 #include <novatel_oem7_driver/oem7_ros_messages.hpp>
 
-#include "novatel_oem7_msgs/msg/rxstatus.hpp"
-#include "novatel_oem7_msgs/msg/terrastarinfo.hpp"
-#include "novatel_oem7_msgs/msg/terrastarstatus.hpp"
+#include "art_novatel_oem7_msgs/msg/rxstatus.hpp"
+#include "art_novatel_oem7_msgs/msg/terrastarinfo.hpp"
+#include "art_novatel_oem7_msgs/msg/terrastarstatus.hpp"
 
 
 namespace novatel_oem7_driver
@@ -334,9 +334,9 @@ namespace novatel_oem7_driver
   /*** Handles RXSTATUS messages */
   class ReceiverStatusHandler: public Oem7MessageHandlerIf
   {
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::RXSTATUS>>         RXSTATUS_pub_;
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::TERRASTARINFO>>    TSTInfo_pub_;
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::TERRASTARSTATUS>>  TSTStatus_pub_;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::RXSTATUS>>         RXSTATUS_pub_;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::TERRASTARINFO>>    TSTInfo_pub_;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::TERRASTARSTATUS>>  TSTStatus_pub_;
 
     std::string frame_id_;
 
@@ -353,9 +353,9 @@ namespace novatel_oem7_driver
       assert(AUX4_STATUS_STRS.size()    == NUM_BITS);
 
 
-      RXSTATUS_pub_  = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::RXSTATUS>>(       "RXSTATUS",        node);
-      TSTInfo_pub_   = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::TERRASTARINFO>>(  "TERRASTARINFO",   node);
-      TSTStatus_pub_ = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::TERRASTARSTATUS>>("TERRASTARSTATUS", node);
+      RXSTATUS_pub_  = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::RXSTATUS>>(       "RXSTATUS",        node);
+      TSTInfo_pub_   = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::TERRASTARINFO>>(  "TERRASTARINFO",   node);
+      TSTStatus_pub_ = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::TERRASTARSTATUS>>("TERRASTARSTATUS", node);
     }
 
     const MessageIdRecords& getMessageIds()
@@ -372,7 +372,7 @@ namespace novatel_oem7_driver
 
     void publishRXSTATUS(Oem7RawMessageIf::ConstPtr msg)
     {
-      std::shared_ptr<novatel_oem7_msgs::msg::RXSTATUS> rxstatus;
+      std::shared_ptr<art_novatel_oem7_msgs::msg::RXSTATUS> rxstatus;
       MakeROSMessage(msg, rxstatus);
 
       // Populate status strings:
@@ -389,14 +389,14 @@ namespace novatel_oem7_driver
 
     void publishTERRASTARINFO(Oem7RawMessageIf::ConstPtr msg)
     {
-        std::shared_ptr<novatel_oem7_msgs::msg::TERRASTARINFO> terrastarinfo;
+        std::shared_ptr<art_novatel_oem7_msgs::msg::TERRASTARINFO> terrastarinfo;
         MakeROSMessage(msg, terrastarinfo);
         TSTInfo_pub_->publish(terrastarinfo);
     }
 
     void publishTERRASTARSTATUS(Oem7RawMessageIf::ConstPtr msg)
     {
-        std::shared_ptr<novatel_oem7_msgs::msg::TERRASTARSTATUS> terrastarstatus;
+        std::shared_ptr<art_novatel_oem7_msgs::msg::TERRASTARSTATUS> terrastarstatus;
         MakeROSMessage(msg, terrastarstatus);
         TSTStatus_pub_->publish(terrastarstatus);
     }

--- a/src/novatel_oem7_driver/src/time_handler.cpp
+++ b/src/novatel_oem7_driver/src/time_handler.cpp
@@ -29,17 +29,17 @@
 
 #include <novatel_oem7_driver/oem7_ros_messages.hpp>
 
-#include "novatel_oem7_msgs/msg/time.hpp"
+#include "art_novatel_oem7_msgs/msg/time.hpp"
 
 namespace novatel_oem7_driver
 {
   class TimeHandler: public Oem7MessageHandlerIf
   {
-    std::unique_ptr<Oem7RosPublisher<novatel_oem7_msgs::msg::TIME>> TIME_pub_;
+    std::unique_ptr<Oem7RosPublisher<art_novatel_oem7_msgs::msg::TIME>> TIME_pub_;
 
     void publishTIME(Oem7RawMessageIf::ConstPtr msg)
     {
-      std::shared_ptr<novatel_oem7_msgs::msg::TIME> time;
+      std::shared_ptr<art_novatel_oem7_msgs::msg::TIME> time;
       MakeROSMessage(msg, time);
       TIME_pub_->publish(time);
     }
@@ -55,7 +55,7 @@ namespace novatel_oem7_driver
 
     void initialize(rclcpp::Node& node)
     {
-      TIME_pub_ = std::make_unique<Oem7RosPublisher<novatel_oem7_msgs::msg::TIME>>("TIME", node);
+      TIME_pub_ = std::make_unique<Oem7RosPublisher<art_novatel_oem7_msgs::msg::TIME>>("TIME", node);
     }
 
     const MessageIdRecords& getMessageIds()

--- a/src/novatel_oem7_msgs/CMakeLists.txt
+++ b/src/novatel_oem7_msgs/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.10)
-project(novatel_oem7_msgs)
+project(art_novatel_oem7_msgs)
 
 
 set(CMAKE_CXX_STANDARD 17)

--- a/src/novatel_oem7_msgs/msg/RANGE.msg
+++ b/src/novatel_oem7_msgs/msg/RANGE.msg
@@ -1,4 +1,4 @@
-std_msgs/Header                       header
-Oem7Header                            nov_header
-uint32                                num_obs
-novatel_oem7_msgs/RANGEOBSERVATION[]  obs
+std_msgs/Header                                 header
+Oem7Header                                      nov_header
+uint32                                          num_obs
+art_novatel_oem7_msgs/RANGEOBSERVATION[]        obs

--- a/src/novatel_oem7_msgs/package.xml
+++ b/src/novatel_oem7_msgs/package.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <package format="3">
-  <name>novatel_oem7_msgs</name>
+  <name>art_novatel_oem7_msgs</name>
   <version>20.1.0</version>
   <description>
       Messages for NovAtel Oem7 family of receivers.


### PR DESCRIPTION
This pull request updates the `novatel_oem7_driver` package to use message definitions from the `art_novatel_oem7_msgs` package instead of the previously used `novatel_oem7_msgs`. The change is applied consistently across build configuration files, headers, and source files, ensuring all message references and dependencies are switched to the new package. This improves compatibility and maintains consistency with the updated message source.

Dependency and build configuration updates:

* Updated all build system references in `CMakeLists.txt` and `package.xml` to depend on `art_novatel_oem7_msgs` instead of `novatel_oem7_msgs`. [[1]](diffhunk://#diff-1ba4c53c509b2eb651a408a39407cf3090f461c510f82106b6442e0631a884eaL19-R19) [[2]](diffhunk://#diff-1ba4c53c509b2eb651a408a39407cf3090f461c510f82106b6442e0631a884eaL124-R124) [[3]](diffhunk://#diff-1ba4c53c509b2eb651a408a39407cf3090f461c510f82106b6442e0631a884eaL133-R133) [[4]](diffhunk://#diff-0a1a78f15f967bb37c48bb5963f0f5869198214927a84f94511c04d0f36cbf72L23-R23)

Header and source file message type changes:

* Replaced all includes and usages of message types from `novatel_oem7_msgs` with their equivalents from `art_novatel_oem7_msgs` in headers and source files such as `oem7_message_decoder_if.hpp`, `oem7_message_util.hpp`, `align_handler.cpp`, `bestpos_handler.cpp`, and `ins_handler.cpp`. [[1]](diffhunk://#diff-f1c59eb0449a8d3a57f51e70ea6e4602ce35bbdfad1ecd6fe834a69db3cd9a71L36-R36) [[2]](diffhunk://#diff-332181b0d6c5294a3275ccb957ad74ff6b5c66e1608f24e812043d75eeee48bfL28-R29) [[3]](diffhunk://#diff-4c220c89c582c11938f495dd18fd2b0204349dbe985b79182c40ccd10ce5823fL31-R33) [[4]](diffhunk://#diff-2e2c9f98f3fe0309de2f7d9cb37ac7ac33bb883cbc944b9adf2ca7f1a7c4cf38L34-R43) [[5]](diffhunk://#diff-69862b598371d0744a115f97fefe987bfb3b905b33ed5d6aeab422e3ec2238c4L38-R43)

Code logic and type usage updates:

* Updated all instances of message type usage, including variable declarations, publisher initializations, and function parameters, to use the new message types from `art_novatel_oem7_msgs`. This includes changes in publisher member variables, message creation, and switch-case statements for message type handling. [[1]](diffhunk://#diff-332181b0d6c5294a3275ccb957ad74ff6b5c66e1608f24e812043d75eeee48bfL74-R74) [[2]](diffhunk://#diff-332181b0d6c5294a3275ccb957ad74ff6b5c66e1608f24e812043d75eeee48bfL83-R83) [[3]](diffhunk://#diff-4c220c89c582c11938f495dd18fd2b0204349dbe985b79182c40ccd10ce5823fL46-R70) [[4]](diffhunk://#diff-4c220c89c582c11938f495dd18fd2b0204349dbe985b79182c40ccd10ce5823fL86-R88) [[5]](diffhunk://#diff-2e2c9f98f3fe0309de2f7d9cb37ac7ac33bb883cbc944b9adf2ca7f1a7c4cf38L62-R69) [[6]](diffhunk://#diff-2e2c9f98f3fe0309de2f7d9cb37ac7ac33bb883cbc944b9adf2ca7f1a7c4cf38L173-R174) [[7]](diffhunk://#diff-2e2c9f98f3fe0309de2f7d9cb37ac7ac33bb883cbc944b9adf2ca7f1a7c4cf38L322-R343) [[8]](diffhunk://#diff-2e2c9f98f3fe0309de2f7d9cb37ac7ac33bb883cbc944b9adf2ca7f1a7c4cf38L409-R409) [[9]](diffhunk://#diff-2e2c9f98f3fe0309de2f7d9cb37ac7ac33bb883cbc944b9adf2ca7f1a7c4cf38L627-R662) [[10]](diffhunk://#diff-2e2c9f98f3fe0309de2f7d9cb37ac7ac33bb883cbc944b9adf2ca7f1a7c4cf38L850-R850) [[11]](diffhunk://#diff-69862b598371d0744a115f97fefe987bfb3b905b33ed5d6aeab422e3ec2238c4L72-R80) [[12]](diffhunk://#diff-69862b598371d0744a115f97fefe987bfb3b905b33ed5d6aeab422e3ec2238c4L109-R109) [[13]](diffhunk://#diff-69862b598371d0744a115f97fefe987bfb3b905b33ed5d6aeab422e3ec2238c4L155-R155)